### PR TITLE
Add CRUD convex functions

### DIFF
--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -61,15 +61,7 @@ export const update = mutation({
     if (!existing) {
       throw new Error(`Document ${args.localId} does not exist.`);
     }
-    if (args.localCreatedAt) {
-      existing.localCreatedAt = args.localCreatedAt;
-    }
-    if (args.body) {
-      existing.body = args.body;
-    }
-    if (args.author) {
-      existing.author = args.author;
-    }
+    Object.assign(existing, args);
     await ctx.db.replace(existing._id, existing);
     return serverToLocalDocument(existing);
   },

--- a/convex/messages.ts
+++ b/convex/messages.ts
@@ -1,28 +1,88 @@
-import { query, mutation } from "./_generated/server";
-import { v } from "convex/values";
+import { query, mutation, QueryCtx } from "./_generated/server";
+import { ConvexError, v } from "convex/values";
 
 export const list = query({
   args: {},
+  returns: v.array(
+    v.object({
+      localId: v.string(),
+      createdAt: v.number(),
+      author: v.string(),
+      body: v.string(),
+    }),
+  ),
   handler: async (ctx) => {
     // Grab the most recent messages.
     const messages = await ctx.db.query("messages").order("desc").take(100);
-    return messages;
+    return messages.map((m) => {
+      // Strip out system provided fields since the client can't generate them.
+      const { _id, _creationTime, ...rest } = m;
+      return rest;
+    });
   },
 });
 
-export const send = mutation({
-  args: { id: v.string(), body: v.string(), author: v.string() },
-  handler: async (ctx, { id, body, author }) => {
-    // Send a new message.
-    await ctx.db.insert("messages", { id, body, author });
+export const create = mutation({
+  args: {
+    localId: v.string(),
+    createdAt: v.number(),
+    body: v.string(),
+    author: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await get(ctx, args.localId);
+    if (existing) {
+      throw new Error(`Document ${args.localId} already exists.`);
+    }
+    const id = await ctx.db.insert("messages", args);
+    const { _id, _creationTime, ...rest } = (await ctx.db.get(id))!;
+    return rest;
   },
 });
 
-// export const update = mutation({
-//   args: { id: v.string(), body: v.string(), author: v.string() },
-//   handler: async (ctx, { id, body, author }) => {
-//     // Update message
-//     // TODO: How to do this with custom id field?
-//     await ctx.db.patch(id, { body, author})
-//   },
-// });
+export const update = mutation({
+  args: {
+    localId: v.string(),
+    createdAt: v.optional(v.number()),
+    body: v.optional(v.string()),
+    author: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const existing = await get(ctx, args.localId);
+    if (!existing) {
+      throw new Error(`Document ${args.localId} does not exist.`);
+    }
+    if (args.createdAt) {
+      existing.createdAt = args.createdAt;
+    }
+    if (args.body) {
+      existing.body = args.body;
+    }
+    if (args.author) {
+      existing.author = args.author;
+    }
+    await ctx.db.replace(existing._id, existing);
+    const { _id, _creationTime, ...rest } = existing;
+    return rest;
+  },
+});
+
+export const remove = mutation({
+  args: { localId: v.string() },
+  handler: async (ctx, args) => {
+    const existing = await get(ctx, args.localId);
+    if (!existing) {
+      throw new Error(`Document ${args.localId} does not exist.`);
+    }
+    await ctx.db.delete(existing._id);
+    const { _id, _creationTime, ...rest } = existing;
+    return rest;
+  },
+});
+
+async function get(ctx: QueryCtx, localId: string) {
+  return await ctx.db
+    .query("messages")
+    .withIndex("byLocalId", (q) => q.eq("localId", localId))
+    .unique();
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,8 +7,9 @@ import { v } from "convex/values";
 // The schema provides more precise TypeScript types.
 export default defineSchema({
   messages: defineTable({
-    id: v.string(),
+    localId: v.string(),
+    createdAt: v.number(),
     author: v.string(),
     body: v.string(),
-  }),
+  }).index("byLocalId", ["localId"]),
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -8,7 +8,7 @@ import { v } from "convex/values";
 export default defineSchema({
   messages: defineTable({
     localId: v.string(),
-    createdAt: v.number(),
+    localCreatedAt: v.number(),
     author: v.string(),
     body: v.string(),
   }).index("byLocalId", ["localId"]),

--- a/src/Chat/Chat.tsx
+++ b/src/Chat/Chat.tsx
@@ -55,14 +55,13 @@ export const Chat = observer(function Chat({ viewer }: { viewer: string }) {
       persist: {
         name: "convexLS2",
       },
-      mode: "assign",
       syncMode: "auto",
     }),
   );
 
   const messages = Object.values(obs$.get() || {});
   const messages2 = Object.values(obs2$.get() || {});
-  messages2.sort((a, b) => b.createdAt - a.createdAt);
+  messages2.sort((a, b) => b.localCreatedAt - a.localCreatedAt);
   console.log("messages", messages, messages2);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -71,7 +70,7 @@ export const Chat = observer(function Chat({ viewer }: { viewer: string }) {
     const localId = generateId();
     obs2$[localId].assign({
       localId,
-      createdAt: Date.now(),
+      localCreatedAt: Date.now(),
       body: newMessageText,
       author: viewer,
     });

--- a/src/lib/convex.ts
+++ b/src/lib/convex.ts
@@ -95,7 +95,7 @@ export function syncedConvex<
 
   return syncedCrud({
     ...rest,
-    mode: mode || "merge",
+    mode: mode || "set",
     list,
     create: async (input: TRemote) => {
       if (createParam) {


### PR DESCRIPTION
I added some basic CRUD Convex functions, with the aim of just getting everything working without making it too pretty yet.
- I renamed `id` to `localId` and added an index to the `messages` table on this field.
- I strip out the server-assigned `_id` and `_creationTime` fields in the API so the client only sees fields it can assign itself. we'll eventually allow the client to assign the `_id` field but we have some backend changes we need to make first.

One issue I'm running into is that server-side deletes seem to get dropped against the local store (see attached video). Is this due to it defaulting to `merge` mode?

https://www.dropbox.com/scl/fi/nsue5lie0m7ioqlu3en05/convex-legendstate.mov?rlkey=bds10b04k0dvntojltvk5xs23&dl=0